### PR TITLE
Initial implememtation for smooth map shift

### DIFF
--- a/crates/input_lib/src/virtual_controller.rs
+++ b/crates/input_lib/src/virtual_controller.rs
@@ -74,6 +74,7 @@ impl Default for ButtonState {
 const INITIAL_DELAY: f32 = 0.25;
 const REPEAT_DELAY: f32 = 0.06;
 pub struct Controller {
+    // TODO This should probably be a vector
     buttons: [(XButton, ButtonKind); 10],
     button_state: ButtonState,
     last_state: ButtonState,

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use macroquad::texture::{Texture2D, load_texture};
+use macroquad::texture::Texture2D;
+use macroquad::texture::load_texture;
 
 #[derive(Debug)]
 pub struct TextureStore {

--- a/src/game.rs
+++ b/src/game.rs
@@ -12,7 +12,7 @@ use macroquad::prelude::*;
 
 pub struct GameContext {
     pub world: WorldState,
-    pub render_context: RenderContext,
+    pub render_ctx: RenderContext,
     pub controller: Controller,
     pub texture_store: TextureStore,
 }
@@ -22,7 +22,7 @@ impl GameContext {
         Self {
             world: WorldState::new(map),
             controller: Controller::new(),
-            render_context,
+            render_ctx: render_context,
             texture_store,
         }
     }
@@ -66,8 +66,7 @@ impl Engine {
         }
         game_ctx.world.setup_turn();
 
-        // Ensure all operations on game_ctx are done before constructing
-        // the statemachine
+        // WARN Ensure all operations on game_ctx are done before constructing the statemachine
         let state_machine = StateMachine::new(&game_ctx);
 
         Self {

--- a/src/state/animation.rs
+++ b/src/state/animation.rs
@@ -1,18 +1,29 @@
 use super::state_machine::{Command, Commands, GameMsg, GameState, Transition};
-use crate::game::GameContext;
+use crate::assets::TextureStore;
 use crate::math::Point;
+use crate::render::RenderContext;
 use crate::unit::Unit;
+use crate::world::WorldState;
 
+use input_lib::Controller;
 use macroquad::math::Vec2;
+use macroquad::prelude::Rect;
 use macroquad::time::get_frame_time;
 
 use std::collections::VecDeque;
+
+const TICK_TIME: f32 = 0.15;
 
 #[derive(Debug)]
 pub struct MoveAnimation {
     timer: f32,
     unit: Unit,
     path: Vec<Point>,
+}
+
+#[derive(Debug)]
+pub struct ShiftMapView {
+    target_rect: Rect,
 }
 
 impl MoveAnimation {
@@ -33,10 +44,12 @@ impl GameState for MoveAnimation {
     fn update(
         &mut self,
         msg_queue: &mut VecDeque<GameMsg>,
-        _game_ctx: &GameContext,
         commands: &mut Commands,
+        _world: &WorldState,
+        _render_ctx: &mut RenderContext,
+        _controller: &Controller,
+        _texture_store: &TextureStore,
     ) -> Transition {
-        let step_time = 0.15;
         self.timer += get_frame_time();
 
         if self.path.is_empty() {
@@ -48,10 +61,10 @@ impl GameState for MoveAnimation {
         let curr_pos: Vec2 = self.unit.pos.into();
         let next_pos: Vec2 = (*self.path.last().unwrap()).into();
         // Normalised
-        let progress = (self.timer / step_time).min(1.0);
+        let progress = (self.timer / TICK_TIME).min(1.0);
         self.unit.render_pos = Some(curr_pos.lerp(next_pos, progress));
 
-        if self.timer >= step_time {
+        if self.timer >= TICK_TIME {
             self.unit.pos = self.path.pop().unwrap();
             if let Some(pos) = self.path.last() {
                 commands.add(Command::FocusView(*pos));
@@ -64,5 +77,72 @@ impl GameState for MoveAnimation {
 
     fn name(&self) -> &'static str {
         "Move Animation"
+    }
+}
+
+impl ShiftMapView {
+    pub fn boxed_new(dest: impl Into<Vec2>, render_ctx: &RenderContext) -> Option<Box<Self>> {
+        const MARGIN: f32 = 2.0;
+        const TOLERANCE: f32 = 1e-3;
+
+        let dest = dest.into();
+        let mut target_rect = render_ctx.map_view_rect;
+
+        let min_x = dest.x - target_rect.w + MARGIN + 1.0;
+        let max_x = dest.x - MARGIN;
+        target_rect.x = target_rect.x.clamp(min_x, max_x);
+
+        let min_y = dest.y - target_rect.h + MARGIN + 1.0;
+        let max_y = dest.y - MARGIN;
+        target_rect.y = target_rect.y.clamp(min_y, max_y);
+
+        target_rect = render_ctx.get_clamped_map_viewport(target_rect);
+        if (target_rect.x - render_ctx.map_view_rect.x).abs() < TOLERANCE
+            && (target_rect.y - render_ctx.map_view_rect.y).abs() < TOLERANCE
+        {
+            return None;
+        }
+
+        Some(Box::new(Self { target_rect }))
+    }
+}
+impl GameState for ShiftMapView {
+    fn update(
+        &mut self,
+        _msg_queue: &mut VecDeque<GameMsg>,
+        _commands_buffer: &mut Commands,
+        _world: &WorldState,
+        render_ctx: &mut RenderContext,
+        _controller: &Controller,
+        _texture_store: &TextureStore,
+    ) -> Transition {
+        const STEP_SIZE: f32 = 0.5;
+        const SNAP_TOLERANCE: f32 = 1e-3;
+
+        let map_rect = &mut render_ctx.map_view_rect;
+
+        let dx = self.target_rect.x - map_rect.x;
+        let dy = self.target_rect.y - map_rect.y;
+        if dx.abs() > 0.0 || dy.abs() > 0.0 {
+            let shift_x = dx.signum() * dx.abs().min(STEP_SIZE);
+            let shift_y = dy.signum() * dy.abs().min(STEP_SIZE);
+
+            map_rect.x += shift_x;
+            map_rect.y += shift_y;
+
+            if (map_rect.x - self.target_rect.x).abs() < SNAP_TOLERANCE {
+                map_rect.x = self.target_rect.x;
+            }
+            if (map_rect.y - self.target_rect.y).abs() < SNAP_TOLERANCE {
+                map_rect.y = self.target_rect.y;
+            }
+            return Transition::None;
+        }
+
+        Transition::Pop
+    }
+
+    fn name(&self) -> &'static str {
+        "Shift Map View"
     }
 }

--- a/src/state/simulated.rs
+++ b/src/state/simulated.rs
@@ -1,11 +1,13 @@
 use super::state_machine::{Command, Commands, GameMsg, GameState, Transition};
-use crate::game::GameContext;
+use crate::assets::TextureStore;
 use crate::pathfinding::{DijkstraMap, get_manahattan_neighbours};
+use crate::render::RenderContext;
 use crate::state::animation::MoveAnimation;
 use crate::state::player::PlayerSelect;
 use crate::unit::Unit;
-use crate::world::Faction;
+use crate::world::{Faction, WorldState};
 
+use input_lib::Controller;
 use macroquad::logging::warn;
 
 use std::collections::VecDeque;
@@ -36,20 +38,23 @@ impl GameState for SimulatedManager {
     fn update(
         &mut self,
         msg_queue: &mut VecDeque<GameMsg>,
-        game_ctx: &GameContext,
         commands: &mut Commands,
+        world: &WorldState,
+        _render_ctx: &mut RenderContext,
+        _controller: &Controller,
+        texture_store: &TextureStore,
     ) -> Transition {
         if let Some(msg) = msg_queue.pop_front() {
             warn!("{} state should not receive msg: {:?}", self.name(), msg);
         }
-        if let Some(unit) = game_ctx.world.get_unmoved_unit(self.faction) {
-            let dijkstra_map = DijkstraMap::new(&game_ctx.world.map, unit, &game_ctx.world.units);
+        if let Some(unit) = world.get_unmoved_unit(self.faction) {
+            let dijkstra_map = DijkstraMap::new(&world.map, unit, &world.units);
             commands.add(Command::FocusView(unit.pos));
             return Transition::Push(MoveSimulated::boxed_new(unit.clone(), dijkstra_map));
         }
 
         commands.add(Command::SetupTurn);
-        Transition::Switch(PlayerSelect::boxed_new(game_ctx))
+        Transition::Switch(PlayerSelect::boxed_new(world, texture_store))
     }
 
     fn name(&self) -> &'static str {
@@ -70,8 +75,11 @@ impl GameState for MoveSimulated {
     fn update(
         &mut self,
         msg_queue: &mut VecDeque<GameMsg>,
-        game_ctx: &GameContext,
         _commands: &mut Commands,
+        world: &WorldState,
+        _render_ctx: &mut RenderContext,
+        _controller: &Controller,
+        _texture_store: &TextureStore,
     ) -> Transition {
         if let Some(msg) = msg_queue.pop_front() {
             match msg {
@@ -86,14 +94,13 @@ impl GameState for MoveSimulated {
         }
 
         // TODO Calculate best unit to target / best point to move to
-        let player_positions = game_ctx
-            .world
+        let player_positions = world
             .units
             .values()
             .filter(|unit| unit.faction == Faction::Player)
             .map(|unit| unit.pos);
         let neighbours = player_positions.flat_map(|pt| get_manahattan_neighbours(pt, 1));
-        let mut empty_tiles = neighbours.filter(|pt| game_ctx.world.is_tile_empty(*pt));
+        let mut empty_tiles = neighbours.filter(|pt| world.is_tile_empty(*pt));
         let maybe_dest = empty_tiles.find(|pt| self.dijkstra_map.get_reachables().contains(pt));
 
         let dest = maybe_dest.unwrap_or(self.unit.pos);
@@ -121,12 +128,14 @@ impl GameState for ActionSimulated {
     fn update(
         &mut self,
         _msg_queue: &mut VecDeque<GameMsg>,
-        game_ctx: &GameContext,
         commands: &mut Commands,
+        world: &WorldState,
+        _render_ctx: &mut RenderContext,
+        _controller: &Controller,
+        _texture_store: &TextureStore,
     ) -> Transition {
         let target = get_manahattan_neighbours(self.unit.pos, 2).find_map(|pt| {
-            game_ctx
-                .world
+            world
                 .units
                 .iter()
                 .find(|(_, unit)| unit.faction == Faction::Player && unit.pos == pt)

--- a/src/state/state_machine.rs
+++ b/src/state/state_machine.rs
@@ -1,3 +1,4 @@
+use input_lib::Controller;
 use macroquad::camera::set_default_camera;
 use macroquad::prelude::set_camera;
 
@@ -5,11 +6,14 @@ use std::collections::VecDeque;
 use std::fmt::Debug;
 
 use super::player::PlayerSelect;
+use crate::assets::TextureStore;
 use crate::cursor::Cursor;
 use crate::game::GameContext;
 use crate::math::Point;
 use crate::render::RenderContext;
+use crate::state::animation::ShiftMapView;
 use crate::unit::{Unit, UnitId};
+use crate::world::WorldState;
 
 #[derive(Debug)]
 pub struct StateMachine {
@@ -20,20 +24,27 @@ pub struct StateMachine {
 impl StateMachine {
     pub fn new(game_ctx: &GameContext) -> Self {
         Self {
-            stack: vec![PlayerSelect::boxed_new(game_ctx)],
+            stack: vec![PlayerSelect::boxed_new(
+                &game_ctx.world,
+                &game_ctx.texture_store,
+            )],
             msg_queue: VecDeque::new(),
             commands_buffer: Commands::new(),
         }
     }
 
     pub fn update(&mut self, game_ctx: &mut GameContext) {
-        game_ctx.render_context.resize_if_required();
+        game_ctx.render_ctx.resize_if_required();
+        let mut view_shift_state = None;
         loop {
             game_ctx.controller.update();
             let transition = self.stack.last_mut().unwrap().update(
                 &mut self.msg_queue,
-                game_ctx,
                 &mut self.commands_buffer,
+                &game_ctx.world,
+                &mut game_ctx.render_ctx,
+                &game_ctx.controller,
+                &game_ctx.texture_store,
             );
             self.commands_buffer
                 .drain()
@@ -45,9 +56,7 @@ impl StateMachine {
                     }
                     Command::SetupTurn => game_ctx.world.setup_turn(),
                     Command::FocusView(pt) => {
-                        // TODO Animate this. Wait for it to finish before proceeding
-                        // TODO May push an animation state?
-                        game_ctx.render_context.shift_viewport(pt);
+                        view_shift_state = ShiftMapView::boxed_new(pt, &game_ctx.render_ctx);
                     }
                     Command::DamageUnit(id, dmg) => {
                         let unit = game_ctx.world.units.get_mut(&id).unwrap();
@@ -61,16 +70,20 @@ impl StateMachine {
                 _ => self.apply_transition(transition),
             }
         }
+
+        if let Some(state) = view_shift_state {
+            self.stack.push(state);
+        }
     }
 
     pub fn render(&self, game_ctx: &GameContext) {
-        set_camera(game_ctx.render_context.camera_ref());
-        game_ctx.render_context.render_map(&game_ctx.world.map);
+        set_camera(game_ctx.render_ctx.camera_ref());
+        game_ctx.render_ctx.render_map(&game_ctx.world.map);
 
         self.stack
-            .last()
-            .unwrap()
-            .render_map_overlay(&game_ctx.render_context);
+            .iter()
+            .rev()
+            .find_map(|state| state.render_map_overlay(&game_ctx.render_ctx));
 
         let mut operating_unit = None;
         for state in self.stack.iter().rev() {
@@ -84,20 +97,20 @@ impl StateMachine {
             .world
             .units
             .iter()
-            .filter(|(_, unit)| game_ctx.render_context.in_bounds(unit.pos))
+            .filter(|(_, unit)| game_ctx.render_ctx.is_point_visible(unit.pos))
             .filter(|(id, _)| operating_unit.is_none_or(|unit| unit.id() != **id))
-            .for_each(|(_, unit)| game_ctx.render_context.render_unit(unit));
+            .for_each(|(_, unit)| game_ctx.render_ctx.render_unit(unit));
 
         if let Some(unit) = operating_unit
-            && game_ctx.render_context.in_bounds(unit.pos)
+            && game_ctx.render_ctx.is_point_visible(unit.pos)
         {
-            game_ctx.render_context.render_unit(unit);
+            game_ctx.render_ctx.render_unit(unit);
         }
 
         self.stack
-            .last()
-            .unwrap()
-            .render_ui_layer(&game_ctx.render_context);
+            .iter()
+            .rev()
+            .find_map(|state| state.render_ui_layer(&game_ctx.render_ctx));
 
         set_default_camera();
         game_ctx.controller.draw(None);
@@ -140,13 +153,20 @@ pub trait GameState: Debug {
     fn update(
         &mut self,
         msg_queue: &mut VecDeque<GameMsg>,
-        game_ctx: &GameContext,
         commands_buffer: &mut Commands,
+        world: &WorldState,
+        render_ctx: &mut RenderContext,
+        controller: &Controller,
+        texture_store: &TextureStore,
     ) -> Transition;
     fn name(&self) -> &'static str;
 
-    fn render_map_overlay(&self, _render_ctx: &RenderContext) {}
-    fn render_ui_layer(&self, _render_ctx: &RenderContext) {}
+    fn render_map_overlay(&self, _render_ctx: &RenderContext) -> Option<()> {
+        None
+    }
+    fn render_ui_layer(&self, _render_ctx: &RenderContext) -> Option<()> {
+        None
+    }
 
     fn active_unit(&self) -> Option<&Unit> {
         None


### PR DESCRIPTION
The cursor currently jitters when moving the cursor causes the viewport to shift.

May be decouple the cursor from map space and store/render it in viewport space. Calculate the map space coordinate when required (check to see if map needs to shift, select the tiles for moving etc.)

That would also be a good time to decouple view rectangle from RenderContext.